### PR TITLE
Use native object merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
   },
   "sideEffects": false,
   "types": "dist/index.d.ts",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -1,6 +1,12 @@
 // src
 import { DEFAULT_OPTIONS, UNGROUPED_NAME } from '../constants';
-import { createBenchmark, getOptions, sortResults, wait } from '../utils';
+import {
+  createBenchmark,
+  getOptions,
+  mergeObjects,
+  sortResults,
+  wait,
+} from '../utils';
 
 describe('createBenchmark', () => {
   it('should create a benchmark without a group assignment', () => {
@@ -51,6 +57,30 @@ describe('getOptions', () => {
     const result = getOptions(passedOptions);
 
     expect(result).toEqual(DEFAULT_OPTIONS);
+  });
+});
+
+describe('mergeObjects', () => {
+  it('should merge the objects passed into a single new object', () => {
+    const object1 = { foo: 'bar' };
+    const object2 = { bar: 'baz' };
+    const object3 = Object.create({
+      fn() {},
+    });
+
+    object3.foo = 'quz';
+
+    const result: { [key: string]: any } = mergeObjects(
+      object1,
+      object2,
+      object3,
+    );
+
+    expect(result).not.toBe(object1);
+    expect(result).not.toBe(object2);
+    expect(result).not.toBe(object3);
+
+    expect(result).toEqual(Object.assign({}, object1, object2, object3));
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 // constants
 import { DEFAULT_OPTIONS, UNGROUPED_NAME } from './constants';
 
+const hasOwnProperty: Function = Object.prototype.hasOwnProperty;
+
 /**
  * create a benchmark object based on the name, group, and fn passed
  * @param name the name of the benchmark
@@ -19,14 +21,37 @@ export const createBenchmark = (
 });
 
 /**
+ * shallowly merge the objects passed into a single new object
+ * @param sources the sources to merge into a single object
+ * @returns the merged object
+ */
+export const mergeObjects = (...sources: Object[]): Object => {
+  const target: { [key: string]: any } = {};
+
+  let source: { [key: string]: any };
+
+  for (let index: number = 0; index < sources.length; index++) {
+    source = sources[index];
+
+    for (const key in source) {
+      if (hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
+/**
  * get the options passed merged with the defaults
  * @param passedOptions the options passed to merge
  * @returns the merged options
  */
 export const getOptions = (passedOptions?: Benchee.Options): Benchee.Options =>
   passedOptions && typeof passedOptions === 'object'
-    ? { ...DEFAULT_OPTIONS, ...passedOptions }
-    : { ...DEFAULT_OPTIONS };
+    ? mergeObjects(DEFAULT_OPTIONS, passedOptions)
+    : mergeObjects(DEFAULT_OPTIONS);
 
 /**
  * sort the results by operations per second (descending)


### PR DESCRIPTION
Replace assign ponyfill provided by typescript with native method. Reduces footprint and improves runtime performance of the merge.