### PR TITLE
[Fix[] Add `release-it` as local dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "cli-table3": "^0.6.5",
     "eslint": "^9.39.1",
     "prettier": "^3.7.4",
+    "release-it": "^19.0.6",
     "rollup": "^4.53.3",
     "typescript": "^5.9.3",
-    "vite": "^7.2.6",
+    "vite": "^7.2.7",
     "vitest": "^4.0.15"
   },
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,9 +1900,10 @@ __metadata:
     cli-table3: "npm:^0.6.5"
     eslint: "npm:^9.39.1"
     prettier: "npm:^3.7.4"
+    release-it: "npm:^19.0.6"
     rollup: "npm:^4.53.3"
     typescript: "npm:^5.9.3"
-    vite: "npm:^7.2.6"
+    vite: "npm:^7.2.7"
     vitest: "npm:^4.0.15"
   languageName: unknown
   linkType: soft
@@ -6290,7 +6291,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.0 || ^7.0.0, vite@npm:^7.2.6":
+"vite@npm:^6.0.0 || ^7.0.0, vite@npm:^7.2.6, vite@npm:^7.2.7":
   version: 7.2.7
   resolution: "vite@npm:7.2.7"
   dependencies:


### PR DESCRIPTION
## Reason for change

To perform releases, `release-it` must be a local dev dependency. Prior to the infra upgrade, it was an expected global.

## Change

Install the package.